### PR TITLE
Update print.c

### DIFF
--- a/src/impl/x86_64/print.c
+++ b/src/impl/x86_64/print.c
@@ -54,7 +54,7 @@ void print_char(char character) {
         return;
     }
 
-    if (col > NUM_COLS) {
+    if (col >= NUM_COLS) {
         print_newline();
     }
 


### PR DESCRIPTION
Off by one bug. Printing a new line when `col > NUM_COLS` prints 81 characters on a single line.