### PR TITLE
Change MacOS in README, remove the $

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Build an image for our build-environment:
 
 Enter build environment:
  - Linux: `docker run --rm -it -v "$pwd":/root/env myos-buildenv`
- - MacOS: `docker run --rm -it -v "$PWD":/root/env myos-buildenv`
+ - MacOS: `docker run --rm -it -v "pwd":/root/env myos-buildenv`
  - Windows (CMD): `docker run --rm -it -v "%cd%":/root/env myos-buildenv`
  - Windows (PowerShell): `docker run --rm -it -v "${pwd}:/root/env" myos-buildenv`
  - NOTE: If you are having trouble with an unshared drive, ensure your docker daemon has access to the drive you're development environment is in. For Docker Desktop, this is in "Settings > Shared Drives" or "Settings > Resources > File Sharing".


### PR DESCRIPTION
For some reason, the daemon goes ballistic if you use $ somewhere in there, here's the error:
**docker: Error response from daemon: create %{$fg[blue]%}%~%{$reset_color%}: "%{$fg[blue]%}%~%{$reset_color%}" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path.**

Removing the $ works fine.