### PR TITLE
Altered docker run command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Build an image for our build-environment:
 ## Build
 
 Enter build environment:
- - Linux: `docker run --rm -it -v "$pwd":/root/env myos-buildenv`
+ - Linux: `docker run --rm -it -v "$PWD":/root/env myos-buildenv`
  - MacOS: `docker run --rm -it -v "$PWD":/root/env myos-buildenv`
  - Windows (CMD): `docker run --rm -it -v "%cd%":/root/env myos-buildenv`
  - Windows (PowerShell): `docker run --rm -it -v "${pwd}:/root/env" myos-buildenv`


### PR DESCRIPTION
Alteration was done since it was found that Linux environment have $PWD set but not $pwd. Since $pwd returns an empty string, this wont cause an error, but the landing location is not same as that as where the source files are.