### PR TITLE
added alignment to the multiboot header

### DIFF
--- a/src/impl/x86_64/boot/header.asm
+++ b/src/impl/x86_64/boot/header.asm
@@ -1,4 +1,5 @@
 section .multiboot_header
+align 8
 header_start:
 	; magic number
 	dd 0xe85250d6 ; multiboot2


### PR DESCRIPTION
the multiboot2 specification requires that the header should be 8 aligned, so i just added align 8 to the header since i noticed that wasn't there 