### PR TITLE
Fix dependencies the bug in Dockerfile

### DIFF
--- a/buildenv/Dockerfile
+++ b/buildenv/Dockerfile
@@ -1,4 +1,4 @@
-FROM randomdude/gcc-cross-x86_64-elf
+FROM maxbalej/gcc-cross-x86_64-elf
 
 RUN apt-get update 
 RUN apt-get upgrade -y


### PR DESCRIPTION
Like in the first video, to create a docker virtual environment you have to run `docker build <the folder contains Dockerfile> -t <your env's name>` like in my case it is `docker build buildenv -t duckos `. However, the _randomdude/gcc-cross-x86_64-elf_ has deprecated dependencies.
> ERROR: failed to solve: randomdude/gcc-cross-x86_64-elf-lt:latest: pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed

In order to fix this, I found a person who fixed it and you could fix this easily just by changing `randomdude` to `maxbalej`  